### PR TITLE
add babel-loader/eslint-loader to list of adopters [skip ci]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,8 @@ This is helpful for actually putting actual files in the cache!
 - [`nyc`](https://github.com/bcoe/nyc)
 - [`AVA`](https://ava.li)
 - [`Phenomic`](https://phenomic.io)
-
+- [`babel-loader`](https://github.com/babel/babel-loader)
+- [`eslint-loader`](https://github.com/MoOx/eslint-loader)
 
 ## License
 


### PR DESCRIPTION
https://github.com/babel/babel-loader#options (we added it last release)
https://github.com/MoOx/eslint-loader#cache-default-false cc @MoOx