### PR TITLE
Require Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
+  - '10'
+  - '8'
   - '6'
-  - '4'
 after_script:
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const pkgDir = require('pkg-dir');
 const makeDir = require('make-dir');
 
 module.exports = options => {
-	const name = options.name;
+	const {name} = options;
 	let dir = options.cwd;
 
 	if (options.files) {
@@ -24,9 +24,7 @@ module.exports = options => {
 		}
 
 		if (options.thunk) {
-			return function () {
-				return path.join.apply(path, [dir].concat(Array.prototype.slice.call(arguments)));
-			};
+			return (...args) => path.join(dir, ...args);
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/jamestalmage"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && nyc ava"
@@ -29,14 +29,14 @@
   "dependencies": {
     "commondir": "^1.0.1",
     "make-dir": "^1.0.0",
-    "pkg-dir": "^2.0.0"
+    "pkg-dir": "^3.0.0"
   },
   "devDependencies": {
-    "ava": "^0.19.1",
-    "coveralls": "^2.11.6",
-    "del": "^2.2.2",
-    "nyc": "^10.3.2",
-    "xo": "^0.18.2"
+    "ava": "^0.25.0",
+    "coveralls": "^3.0.1",
+    "del": "^3.0.0",
+    "nyc": "^12.0.2",
+    "xo": "^0.21.1"
   },
   "nyc": {
     "reporter": [

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('creates dir', t => {
 	t.true(fs.existsSync(dir));
 });
 
-test.only('thunk', t => {
+test('thunk', t => {
 	const dir = path.join(__dirname, 'node_modules', '.cache', 'thunked');
 	del.sync(dir);
 	const thunk = fn({thunk: true, name: 'thunked', cwd: __dirname});


### PR DESCRIPTION
- Remove `.only` from one of the tests
- Drop support for Node.js 4
- Add Node.js 8 & 10 to Travis
- Update all dev-dependencies