### PR TITLE
Update make-dir to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	],
 	"dependencies": {
 		"commondir": "^1.0.1",
-		"make-dir": "^1.0.0",
+		"make-dir": "^2.0.0",
 		"pkg-dir": "^3.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
[Release notes](https://github.com/sindresorhus/make-dir/releases/tag/v2.0.0)

The main difference is that `make-dir` now uses the native recursive option on recent Node.js versions.