### PR TITLE
Tolerate lack of `node_modules` when checking if directory is writable

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,11 @@ module.exports = (options = {}) => {
 	directory = pkgDir.sync(directory);
 
 	if (directory) {
-		if (!isWritable(path.join(directory, 'node_modules'))) {
-			return undefined;
+		const nodeModules = path.join(directory, 'node_modules');
+		if (!isWritable(nodeModules)) {
+			if (fs.existsSync(nodeModules) || !isWritable(path.join(directory))) {
+				return undefined;
+			}
 		}
 
 		directory = path.join(directory, 'node_modules', '.cache', name);


### PR DESCRIPTION
Do not return undefined when `node_modules` does not exist but can be
created.

---

nyc testing found this issue.