### PR TITLE
feat!: upgrade Node.js minimum supported version to 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
-          - 16
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	],
 	"dependencies": {
 		"common-path-prefix": "^3.0.0",
-		"pkg-dir": "^7.0.0"
+		"pkg-dir": "^8.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
Hi, this PR upgrades pkg-dir ^7.0 to ^8.0, which reduces the dependencies tree and bandwidth consumption:

```
Package size report
===================

Package info for "find-cache-dir@5.0.0": 71 kB
  Released: 2023-08-18 23:47:06.336 +0000 UTC (53w5d ago)
  Downloads last week: 120,595 (0.34%)
  Estimated traffic last week: 8.6 GB
  Subdependencies: 8

Removed dependencies:
  - pkg-dir@7.0.0: 59 kB (82.96%)
    Downloads last week: 6,364,454 (N/A% from 7.0.0)
    Downloads last week from "find-cache-dir@5.0.0": 120,595 (N/A%)
    Traffic last week: N/A
    Traffic from "find-cache-dir@5.0.0": 8.6 GB (N/A%)
    Subdependencies: 6 (75%)

Added dependencies:
  + pkg-dir@8.0.0: 13 kB (18.48%)
    Downloads last week: 38,758 (N/A% from 8.0.0)
    Estimated traffic last week: N/A
    Subdependencies: 1 (12.5%)

Estimated new statistics:
  Package size: 71 kB → 18 kB (24.61%)
  Subdependencies: 8 → 3 (-5)
  Traffic with last week's downloads:
    For current version: 8.6 GB → 2.1 GB (6.5 GB saved)
    For all versions: 2.5 TB → 615 GB (1.9 TB saved)
```

Before:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/e556c493-df1b-4724-910e-aa2e2511e995">


After:
<img width="477" alt="image" src="https://github.com/user-attachments/assets/a2a38e02-f90d-4fb1-8a45-67009e3f7000">


Since pkg-dir@^8.0 requires Node.js 18, we must requires Node.js 18 here too. This update is a breaking change ... or not, depending if dropping a non-maintained version is a BC or not.

Thanks :)